### PR TITLE
[#254] temporary fix for scoped storage error in Android 10

### DIFF
--- a/caddisfly-app/app/src/main/AndroidManifest.xml
+++ b/caddisfly-app/app/src/main/AndroidManifest.xml
@@ -42,6 +42,7 @@
         android:name=".app.CaddisflyApp"
         android:allowBackup="true"
         android:extractNativeLibs="false"
+        android:requestLegacyExternalStorage="true"
         android:fullBackupContent="@xml/backup_scheme"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/appName"


### PR DESCRIPTION
On Android 10 the external Storage is now scoped. The app uses the old logic to access files, temporarily enable this flag until we start using the scoped storage the proper way.